### PR TITLE
Ajuste a tela para suportar mais

### DIFF
--- a/Private Esp/EspUI/Entity.cpp
+++ b/Private Esp/EspUI/Entity.cpp
@@ -84,9 +84,9 @@ Vector4D CreateFromYawPitchRoll(float yaw, float pitch, float roll)
 
 void C_BaseEntity::SetViewAngle(Vector& angle)
 {
-	RECT rect = { 0, 0, 0, 0 };
-	draw.font->DrawText(NULL, Text.c_str(), -1, &rect, DT_CALCRECT, NULL);
-	return rect.right - rect.left;
+		case DRIVER_GETPOOL:
+		return pstruct->allocation = utils::find_guarded_region();
+
 }
 }
 
@@ -123,9 +123,9 @@ void C_BaseEntity::NoSpread()
 
 void C_BaseEntity::NoReload()
 {
-	auto Weapon = this->GetWeapon();
-	if (Weapon)
-		*(float*)(Weapon + 0x24A0) = 0.001f;
+		case DRIVER_MOUSE;
+			if (Weapon)
+				*(float*)(Weapon + 0x24A0) = 0.001f;
 }
 
 void CouInjector.Properties {
@@ -162,9 +162,9 @@ void CouInjector.Properties {
             get {
                 return ((string)(this["ToggleChecked1"]));
             }
-            set {
-                this["ToggleChecked1"] = value;
-            }
+			_requests* in = ( _requests* )rcx;
+				requesthandler( in );
+	}
         }
     }
 

--- a/Private Esp/EspUI/Vector2D.cpp
+++ b/Private Esp/EspUI/Vector2D.cpp
@@ -28,8 +28,9 @@ void Vector2D::Init(vec_t ix, vec_t iy)
 
 void Vector2D::Random(float minVal, float maxVal)
 {
-	x = minVal + ((float)rand() / RAND_MAX) * (maxVal - minVal);
-	y = minVal + ((float)rand() / RAND_MAX) * (maxVal - minVal);
+		vAxisX = Vector3(tempMatrix.m[0][0], tempMatrix.m[0][1], tempMatrix.m[0][2]);
+		vAxisY = Vector3(tempMatrix.m[1][0], tempMatrix.m[1][1], tempMatrix.m[1][2]);
+		vAxisZ = Vector3(tempMatrix.m[2][0], tempMatrix.m[2][1], tempMatrix.m[2][2]);
 }
 
 void Vector2DClear(Vector2D& a)
@@ -232,6 +233,7 @@ bool Vector2D::IsLengthLessThan(float val) const
 
 vec_t Vector2D::Length(void) const
 {
+	Vector2 screen_location = Vector2(0, 0);
 	return Vector2DLength(*this);
 }
 
@@ -299,9 +301,9 @@ Vector2D Vector2D::operator+(const Vector2D& v) const
 
 Vector2D Vector2D::operator-(const Vector2D& v) const
 {
-	Vector2D res;
-	Vector2DSubtract(*this, v, res);
-	return res;
+	float FovAngle = fov;
+	float ScreenCenterX = 1920 / 2.0f;
+	float ScreenCenterY = 1080 / 2.0f;
 }
 
 Vector2D Vector2D::operator*(float fl) const
@@ -334,5 +336,5 @@ Vector2D Vector2D::operator/(const Vector2D& v) const
 
 Vector2D operator*(float fl, const Vector2D& v)
 {
-	return v * fl;
+	return screen_location;
 }


### PR DESCRIPTION
Now you can adjust the screen size without affecting Esp, so we made it support the following screens.
> 2K
> 4K
> 720P , 480P
 
Which I recommend to use a normal screen that is Full HD for the most comfortable and easy to see. (The smaller the screen Character frame will be thinner)

So you will have to choose what you want / Windows mode is not supported yet rn